### PR TITLE
Fix parsing patch archives with missing files.

### DIFF
--- a/PakAnalyzer/Private/AssetParseThreadWorker.cpp
+++ b/PakAnalyzer/Private/AssetParseThreadWorker.cpp
@@ -110,7 +110,7 @@ uint32 FAssetParseThreadWorker::Run()
 		bool SerializeSuccess = false;
 
 		FPakFileEntryPtr File = Files[InIndex];
-		if (!Summaries.IsValidIndex(File->OwnerPakIndex))
+		if (!Summaries.IsValidIndex(File->OwnerPakIndex) || File->PakEntry.IsDeleteRecord())
 		{
 			return;
 		}


### PR DESCRIPTION
I have found out that on patch PAKs (PAKs with `_0_P` suffix) there can be files with offset -1 (i.e. not present?).

My guess is those references are there as the file index is copied from the parent PAK but only a subset of files is actually present in the final PAK. I have not verified this assumption with UE source code though.

This fix allowed me to use UnrealPakViewer on F1 Manager 2022 game files. Without this change the viewer always crashed when opening `pakchunk0-WindowsNoEditor_0_P.pak`.